### PR TITLE
Added docker image support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,7 @@ RUN mvn -f /dd/pom.xml clean package
 
 FROM openjdk:14.0.2-slim
 COPY --from=build /dd/target/dd-backend.jar /dd/dd-backend.jar
+RUN apt-get update -y && apt-get upgrade -y
+RUN apt-get install tesseract-ocr -y
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","/dd/dd-backend.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM maven:3.6.3-jdk-14 AS build
+COPY src /dd/src
+COPY pom.xml /dd
+RUN mvn -f /dd/pom.xml clean package
+
+FROM openjdk:14.0.2-slim
+COPY --from=build /dd/target/dd-backend.jar /dd/dd-backend.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/dd/dd-backend.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ FROM openjdk:14.0.2-slim
 COPY --from=build /dd/target/dd-backend.jar /dd/dd-backend.jar
 RUN apt-get update -y && apt-get upgrade -y
 RUN apt-get install tesseract-ocr -y
+ENV LC_ALL=C
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","/dd/dd-backend.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
     </dependencies>
 
     <build>
+        <finalName>dd-backend</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Make the project containerized with a staged build. 
Compile the project with maven on the "build" stage and copy the jar to the next stage.
On the next stage install tesseract-ocr dependency and set the default env